### PR TITLE
Replace /ClientLogin with /ClientAuth

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -312,7 +312,7 @@ class AbstractRpcServer(object):
       # Needed for use inside Google.
       account_type = "HOSTED"
     req = self._CreateRequest(
-        url="https://www.google.com/accounts/ClientLogin",
+        url="https://www.google.com/accounts/ClientAuth",
         data=urllib.urlencode({
             "Email": email,
             "Passwd": password,


### PR DESCRIPTION
Currently upload.py is broken across many Google projects.  Rather than just making the one-line change locally, I wanted to share it with you.