### PR TITLE
Fix 'o' keyboard shortcut on dashboard page.

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -2825,7 +2825,7 @@ function M_dashboardKeyDown(evt) {
       if (dashboardState) {
 	var child = dashboardState.curTR.cells[2].firstChild;
 	while (child && child.nodeName != "A") {
-	  child = child.firstChild;
+	  child = child.firstElementChild;
 	}
 	if (child) {
 	  location.href = child.href;


### PR DESCRIPTION
Change firstChild to firstElementChild. The while loop was selecting the whitespace text node instead of its sibling anchor tag.