### PR TITLE
Fixing SVN patch generation with new error code

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -1395,7 +1395,7 @@ class SubversionVCS(VersionControlSystem):
         if returncode:
           # Directory might not yet exist at start revison
           # svn: Unable to find repository location for 'abc' in revision nnn
-          if re.match('^svn: Unable to find repository location for .+ in revision \d+', err):
+          if re.match('^svn:( E195012:)? Unable to find repository location for .+ in revision \d+', err):
             old_files = ()
           else:
             ErrorExit("Failed to get status for %s:\n%s" % (filename, err))


### PR DESCRIPTION
The current error message in SVN when it can't find a remote file is `svn: E195012: Unable to find repository location for ...`.  However, the regex was looking for `svn: Unable to find repository location for ...` without the `E195012:`.  This patch allows the `E195012:` to optionally be present in the regex match.