### PR TITLE
Use mercurial subrepos option to generate diff

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -1823,7 +1823,7 @@ class MercurialVCS(VersionControlSystem):
     return os.path.relpath(absname)
 
   def GenerateDiff(self, extra_args):
-    cmd = ["hg", "diff", "--git", "-r", self.base_rev] + extra_args
+    cmd = ["hg", "diff", "--git", "-S", "-r", self.base_rev] + extra_args
     data = RunShell(cmd, silent_ok=True)
     svndiff = []
     filecount = 0
@@ -1849,7 +1849,7 @@ class MercurialVCS(VersionControlSystem):
   def GetUnknownFiles(self):
     """Return a list of files unknown to the VCS."""
     args = []
-    status = RunShell(["hg", "status", "--rev", self.base_rev, "-u", "."],
+    status = RunShell(["hg", "status", "-S", "--rev", self.base_rev, "-u", "."],
         silent_ok=True)
     unknown_files = []
     for line in status.splitlines():
@@ -1866,7 +1866,7 @@ class MercurialVCS(VersionControlSystem):
     is_binary = False
     oldrelpath = relpath = self._GetRelPath(filename)
     # "hg status -C" returns two lines for moved/copied files, one otherwise
-    out = RunShell(["hg", "status", "-C", "--rev", self.base_rev, relpath])
+    out = RunShell(["hg", "status", "-S", "-C", "--rev", self.base_rev, relpath])
     out = out.splitlines()
     # HACK: strip error message about missing file/directory if it isn't in
     # the working copy


### PR DESCRIPTION
At Tryton, we started to use subrepo from mercurial but upload.py does not generate a diff for subrepo which make the review workflow less useful as we need to scatter patch in multiple reviews. So I propose to generate a diff including the subrepositories by default.

On non-subrepo, the option does nothing and on subrepo it generate a
diff for all the repositories which is probably the most expected
behavior.