### PR TITLE
Allow space in diff'ed filename extracted from regexp

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -1829,7 +1829,7 @@ class MercurialVCS(VersionControlSystem):
     svndiff = []
     filecount = 0
     for line in data.splitlines():
-      m = re.match("diff --git a/(\S+) b/(\S+)", line)
+      m = re.match("diff --git a/(.+) b/(.+)", line)
       if m:
         # Modify line to make it look like as it comes from svn diff.
         # With this modification no changes on the server side are required


### PR DESCRIPTION
The files modified can contain spaces but the regexp does not match them and so the patch can not be uploaded.